### PR TITLE
Modify migration directory to db/migrate

### DIFF
--- a/lib/msplex/generator.rb
+++ b/lib/msplex/generator.rb
@@ -96,11 +96,11 @@ module Msplex
 
     def generate_migration_file(migration, index, base_dir)
       filename = "#{sprintf('%03d', index + 1)}_#{migration[:name]}.rb"
-      open(File.join(base_dir, "db", filename), "w+") { |f| f.puts migration[:migration] }
+      open(File.join(base_dir, "db", "migrate", filename), "w+") { |f| f.puts migration[:migration] }
     end
 
     def generate_migration_files(database, base_dir)
-      FileUtils.mkdir(File.join(base_dir, "db"))
+      FileUtils.mkdir_p(File.join(base_dir, "db", "migrate"))
       database.migrations.each.with_index { |migration, index| generate_migration_file(migration, index, base_dir) }
     end
 

--- a/spec/lib/msplex/generator_spec.rb
+++ b/spec/lib/msplex/generator_spec.rb
@@ -589,7 +589,7 @@ MIGRATION
 
       it "should generate migration file" do
         subject
-        expect(open(File.join(out_dir, "services", "hogeservice", "db", "001_create_users.rb")).read).to match(/class CreateUsers/)
+        expect(open(File.join(out_dir, "services", "hogeservice", "db", "migrate", "001_create_users.rb")).read).to match(/class CreateUsers/)
       end
     end
   end


### PR DESCRIPTION
`rake db:migrate` loads files under `db/migrate`, not `db`.
