### PR TITLE
Do not assign any parameter if action is list

### DIFF
--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -225,7 +225,7 @@ RAKEFILE
   content_type :json
   result = {}
 
-#{Utils.indent(database.params(action[:table]), 2)}
+#{defined[:params] ? Utils.indent(database.params(action[:table]), 2) : ""}
 #{Utils.indent(db_action, 2)}
 
   result.to_json

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -120,8 +120,7 @@ class App < Sinatra::Base
     content_type :json
     result = {}
 
-    user_name = params[:users][:name]
-    user_description = params[:users][:description]
+
     users = User.all
     result[:users] = users
 


### PR DESCRIPTION
`list` action gets all items from table, so we do not have to assign variables from request parameters.
