### PR TITLE
Smart naming of Service and Database

### DIFF
--- a/examples/e-commerce/application.yml
+++ b/examples/e-commerce/application.yml
@@ -1,5 +1,7 @@
 name: E-commerce
 maintainer: Tanaka taro
 links:
-  - "cartservice:cartdb"
-  - "catalogservice:catalogdb"
+  - service: cart
+    database: cart
+  - service: catalog
+    database: catalog

--- a/examples/e-commerce/databases/cart.yml
+++ b/examples/e-commerce/databases/cart.yml
@@ -1,4 +1,4 @@
-name: cartdb
+name: cart
 type: rdb
 tables:
   carts:

--- a/examples/e-commerce/databases/catalog.yml
+++ b/examples/e-commerce/databases/catalog.yml
@@ -1,4 +1,4 @@
-name: catalogdb
+name: catalog
 type: rdb
 tables:
   items:

--- a/examples/e-commerce/services/cart.yml
+++ b/examples/e-commerce/services/cart.yml
@@ -1,4 +1,4 @@
-name: cartservice
+name: cart
 actions:
   - type: create
     table: carts

--- a/examples/e-commerce/services/catalog.yml
+++ b/examples/e-commerce/services/catalog.yml
@@ -1,4 +1,4 @@
-name: catalogservice
+name: catalog
 actions:
   - type: list
     table: items

--- a/lib/msplex/generator.rb
+++ b/lib/msplex/generator.rb
@@ -12,8 +12,8 @@ module Msplex
 
     def generate_compose
       compose_yml = { frontend: @frontend.compose(@services) }
-      service_database_pairs.each { |service, database| compose_yml[service.name] = service.compose(database) }
-      @databases.each { |database| compose_yml[database.name] = database.compose }
+      service_database_pairs.each { |service, database| compose_yml[service.compose_service_name] = service.compose(database) }
+      @databases.each { |database| compose_yml[database.compose_service_name] = database.compose }
       write_compose(compose_yml)
     end
 
@@ -114,8 +114,7 @@ module Msplex
 
     def service_database_pairs
       @service_database_pairs ||= @application.links.map do |link|
-        service, database = *link.split(":")
-        [@services.find { |s| s.name == service }, @databases.find { |d| d.name == database }]
+        [@services.find { |s| s.name == link[:service] }, @databases.find { |d| d.name == link[:database] }]
       end
     end
 

--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -217,7 +217,7 @@ ENDPOINT
       end
 
       def links(services)
-        services.map { |service| "#{service.name}:#{service.name}" }
+        services.map { |service| "#{service.compose_service_name}:#{service.name}" }
       end
 
       def navbar_items

--- a/lib/msplex/resource/kvs.rb
+++ b/lib/msplex/resource/kvs.rb
@@ -14,6 +14,10 @@ module Msplex
         }
       end
 
+      def compose_service_name
+        @compose_service_name ||= "#{@name}_db"
+      end
+
       def config
         ""
       end

--- a/lib/msplex/resource/rdb.rb
+++ b/lib/msplex/resource/rdb.rb
@@ -14,6 +14,10 @@ module Msplex
         }
       end
 
+      def compose_service_name
+        @compose_service_name ||= "#{@name}_db"
+      end
+
       def config
         <<-CONFIG
 default: &default

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -43,6 +43,10 @@ module Msplex
         }
       end
 
+      def compose_service_name
+        @compose_service_name ||= "#{@name}_service"
+      end
+
       def app_rb(database)
         <<-APPRB
 #{database.definitions.join("\n")}

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -243,7 +243,7 @@ ENDPOINT
       end
 
       def links(database)
-        database ? ["#{database.name}:db"] : []
+        database ? ["#{database.compose_service_name}:db"] : []
       end
     end
   end

--- a/spec/fixtures/valid_application.yml
+++ b/spec/fixtures/valid_application.yml
@@ -1,5 +1,7 @@
 name: sample
 maintainer: Tanaka Taro
 links:
-  - "hogeservice:hogedb"
-  - "fugaservice:fugadb"
+  - service: hoge
+    database: hoge
+  - service: fuga
+    database: fuga

--- a/spec/fixtures/valid_database.yml
+++ b/spec/fixtures/valid_database.yml
@@ -1,4 +1,4 @@
-name: sampledb
+name: sample
 type: rdb
 tables:
   users:

--- a/spec/fixtures/valid_service.yml
+++ b/spec/fixtures/valid_service.yml
@@ -1,4 +1,4 @@
-name: sampleservice
+name: sample
 actions:
   - type: get
   - type: list

--- a/spec/lib/msplex/resource/application_spec.rb
+++ b/spec/lib/msplex/resource/application_spec.rb
@@ -30,7 +30,7 @@ module Msplex
           it { is_expected.to be_a described_class }
           its(:name) { is_expected.to eq "sample" }
           its(:maintainer) { is_expected.to eq "Tanaka Taro" }
-          its(:links) { is_expected.to eql ["hogeservice:hogedb", "fugaservice:fugadb"] }
+          its(:links) { is_expected.to eql [{ service: "hoge", database: "hoge" }, { service: "fuga", database: "fuga" }] }
         end
 
         context "when the given schema is invalid" do

--- a/spec/lib/msplex/resource/database_spec.rb
+++ b/spec/lib/msplex/resource/database_spec.rb
@@ -8,7 +8,7 @@ module Msplex
       end
 
       let(:name) do
-        "sampledb"
+        "sample"
       end
 
       let(:tables) do
@@ -38,7 +38,7 @@ module Msplex
           end
 
           it { is_expected.to be_a described_class }
-          its(:name) { is_expected.to eq "sampledb" }
+          its(:name) { is_expected.to eq "sample" }
           its(:tables) { is_expected.to eql({ users: [{ key: "name", type: "string" }, { key: "description", type: "string" }] }) }
         end
 

--- a/spec/lib/msplex/resource/frontend_spec.rb
+++ b/spec/lib/msplex/resource/frontend_spec.rb
@@ -108,8 +108,8 @@ APPRB
         context "when the frontend has services" do
           let(:services) do
             [
-              double(:hoge_service, name: "hoge"),
-              double(:fuga_service, name: "fuga"),
+              double(:hoge, name: "hoge", compose_service_name: "hoge_service"),
+              double(:fuga, name: "fuga", compose_service_name: "fuga_service"),
             ]
           end
 
@@ -117,8 +117,8 @@ APPRB
             expect(subject).to eql({
               build: "frontend",
               links: [
-                "hoge:hoge",
-                "fuga:fuga",
+                "hoge_service:hoge",
+                "fuga_service:fuga",
               ],
               ports: [
                 "80:9292"

--- a/spec/lib/msplex/resource/kvs_spec.rb
+++ b/spec/lib/msplex/resource/kvs_spec.rb
@@ -4,7 +4,7 @@ module Msplex
   module Resource
     describe KVS do
       let(:name) do
-        "sampledb"
+        "sample"
       end
 
       let(:tables) do
@@ -36,6 +36,12 @@ module Msplex
             image: "redis:3.0",
           })
         end
+      end
+
+      describe "#compose_service_name" do
+        subject { kvs.compose_service_name }
+
+        it { is_expected.to eq "sample_db" }
       end
 
       describe "#config" do

--- a/spec/lib/msplex/resource/rdb_spec.rb
+++ b/spec/lib/msplex/resource/rdb_spec.rb
@@ -4,7 +4,7 @@ module Msplex
   module Resource
     describe RDB do
       let(:name) do
-        "sampledb"
+        "sample"
       end
 
       let(:tables) do
@@ -39,6 +39,12 @@ module Msplex
         end
       end
 
+      describe "#compose_service_name" do
+        subject { rdb.compose_service_name }
+
+        it { is_expected.to eq "sample_db" }
+      end
+
       describe "#config" do
         subject { rdb.config }
 
@@ -54,15 +60,15 @@ default: &default
 
 development:
   <<: *default
-  database: sampledb_development
+  database: sample_development
 
 test:
   <<: *default
-  database: sampledb_test
+  database: sample_test
 
 production:
   <<: *default
-  database: sampledb_production
+  database: sample_production
 CONFIG
         end
       end

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -163,6 +163,12 @@ APPRB
         end
       end
 
+      describe "#compose_service_name" do
+        subject { service.compose_service_name}
+
+        it { is_expected.to eq "sample_service" }
+      end
+
       describe "#config_ru" do
         subject { service.config_ru }
 

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -4,7 +4,7 @@ module Msplex
   module Resource
     describe Service do
       let(:name) do
-        "sampleservice"
+        "sample"
       end
 
       let(:actions) do
@@ -27,7 +27,7 @@ module Msplex
           end
 
           it { is_expected.to be_a described_class }
-          its(:name) { is_expected.to eq "sampleservice" }
+          its(:name) { is_expected.to eq "sample" }
           its(:actions) { is_expected.to eql [{ type: "get" }, { type: "list" }] }
         end
 
@@ -141,7 +141,7 @@ APPRB
 
           it "should generate docker-compose.yml linked with database" do
             expect(subject).to eql({
-              build: "services/sampleservice",
+              build: "services/sample",
               links: [
                 "sampleservice-db:db",
               ],
@@ -156,7 +156,7 @@ APPRB
 
           it "should generate docker-compose.yml" do
             expect(subject).to eql({
-              build: "services/sampleservice",
+              build: "services/sample",
               links: [],
             })
           end

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -136,14 +136,14 @@ APPRB
 
         context "when the service has database" do
           let(:database) do
-            double(:database, name: "sampleservice-db", gem: { gem: "pg", version: "0.18.3" })
+            double(:database, name: "sample", compose_service_name: "sample_db", gem: { gem: "pg", version: "0.18.3" })
           end
 
           it "should generate docker-compose.yml linked with database" do
             expect(subject).to eql({
               build: "services/sample",
               links: [
-                "sampleservice-db:db",
+                "sample_db:db",
               ],
             })
           end


### PR DESCRIPTION
## WHY

Naming with resource suffix, e.g. `hogeservice`, `hogedb`, is bothersome. 
## WHAT

Add resource suffix automatically. We just name them with `hoge`, `fuga`.
