### PR TITLE
Parse JSON params

### DIFF
--- a/lib/msplex/resource/kvs.rb
+++ b/lib/msplex/resource/kvs.rb
@@ -39,9 +39,11 @@ module Msplex
       end
 
       def params(table)
-        tables[table.to_sym].map do |field|
-          "#{table.to_s.singularize}_#{field[:key]} = params[:#{table}][:#{field[:key]}]"
-        end.join("\n") << "\n"
+        [
+          "json_params = JSON.parse(request.body.read)"
+        ].concat(
+          tables[table.to_sym].map { |field| "#{table.to_s.singularize}_#{field[:key]} = json_params[:#{table}][:#{field[:key]}]" }
+        ).join("\n") << "\n"
       end
 
       def list(table)

--- a/lib/msplex/resource/rdb.rb
+++ b/lib/msplex/resource/rdb.rb
@@ -60,8 +60,11 @@ CONFIG
 
       def params(table)
         [
+          "json_params = JSON.parse(request.body.read)",
           param_assignment_statement(table, "id")
-        ].concat(tables[table.to_sym].map { |field| param_assignment_statement(table, field[:key]) }).join("\n") << "\n"
+        ].concat(
+          tables[table.to_sym].map { |field| param_assignment_statement(table, field[:key]) }
+        ).join("\n") << "\n"
       end
 
       def list(table)
@@ -127,7 +130,7 @@ DEFINITION
       end
 
       def param_assignment_statement(table, param)
-        "#{param_name_of(table, param)} = params[:#{table}][:#{param}]"
+        "#{param_name_of(table, param)} = json_params[:#{table}][:#{param}]"
       end
 
       def param_name_of(table, param)

--- a/spec/lib/msplex/resource/kvs_spec.rb
+++ b/spec/lib/msplex/resource/kvs_spec.rb
@@ -98,21 +98,6 @@ DEFINITIONS
         it { is_expected.to eq "" }
       end
 
-      describe "#params" do
-        let(:table) do
-          :users
-        end
-
-        subject { kvs.params(table) }
-
-        it "should generate assignment statements" do
-          expect(subject).to eq <<-PARAMS
-user_name = params[:users][:name]
-user_description = params[:users][:description]
-PARAMS
-        end
-      end
-
       describe "#list" do
         let(:table) do
           :users
@@ -125,6 +110,21 @@ PARAMS
 users = User.all.to_a
 result[:users] = users
 LIST
+        end
+      end
+
+      describe "#params" do
+        let(:table) do
+          :users
+        end
+
+        subject { kvs.params(table) }
+
+        it "should generate assignment statements" do
+          expect(subject).to eq <<-PARAMS
+user_name = params[:users][:name]
+user_description = params[:users][:description]
+PARAMS
         end
       end
 

--- a/spec/lib/msplex/resource/kvs_spec.rb
+++ b/spec/lib/msplex/resource/kvs_spec.rb
@@ -122,8 +122,9 @@ LIST
 
         it "should generate assignment statements" do
           expect(subject).to eq <<-PARAMS
-user_name = params[:users][:name]
-user_description = params[:users][:description]
+json_params = JSON.parse(request.body.read)
+user_name = json_params[:users][:name]
+user_description = json_params[:users][:description]
 PARAMS
         end
       end

--- a/spec/lib/msplex/resource/rdb_spec.rb
+++ b/spec/lib/msplex/resource/rdb_spec.rb
@@ -160,9 +160,10 @@ MIGRATION
 
         it "should generate assignment statements" do
           expect(subject).to eq <<-PARAMS
-user_id = params[:users][:id]
-user_name = params[:users][:name]
-user_description = params[:users][:description]
+json_params = JSON.parse(request.body.read)
+user_id = json_params[:users][:id]
+user_name = json_params[:users][:name]
+user_description = json_params[:users][:description]
 PARAMS
         end
       end

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -44,8 +44,9 @@ class User < ActiveRecord::Base
 end
 DEFINITION
             params: <<-PARAMS,
-user_name = params[:users][:name]
-user_description = params[:users][:description]
+json_params = JSON.parse(request.body.read)
+user_name = json_params[:users][:name]
+user_description = json_params[:users][:description]
 
 PARAMS
             list: <<-LIST,
@@ -106,8 +107,9 @@ class App < Sinatra::Base
     content_type :json
     result = {}
 
-    user_name = params[:users][:name]
-    user_description = params[:users][:description]
+    json_params = JSON.parse(request.body.read)
+    user_name = json_params[:users][:name]
+    user_description = json_params[:users][:description]
     user = User.new(name: user_name)
     user.save!
     result[:users] ||= []


### PR DESCRIPTION
## WHY

Currently `params` does not accept `application/json` parameter. We have to parse request body manually.
