### PR TITLE
Launch service at 80/tcp

### DIFF
--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -118,8 +118,8 @@ RUN bundle install --without test development --system
 
 ADD . /usr/src/app
 
-EXPOSE 9292
-CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
+EXPOSE 80
+CMD ["bundle", "exec", "rackup", "-p", "80", "-E", "production"]
 DOCKERFILE
       end
 

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -207,8 +207,8 @@ RUN bundle install --without test development --system
 
 ADD . /usr/src/app
 
-EXPOSE 9292
-CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
+EXPOSE 80
+CMD ["bundle", "exec", "rackup", "-p", "80", "-E", "production"]
           DOCKERFILE
         end
       end


### PR DESCRIPTION
This enables frontend to access to services without port number

e.g. `http://cart/items`
