### PR TITLE
Accept empty parameters at #http_get

### DIFF
--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -34,8 +34,8 @@ class App < Sinatra::Base
       parameters.map { |key, value| key.to_s + "=" + CGI.escape(value.to_s) }.join("&")
     end
 
-    def http_get(endpoint, parameters)
-      uri = URI.parse(endpoint + "?" + param_str(parameters))
+    def http_get(endpoint, parameters = {})
+      uri = URI.parse(parameters.length > 0 ? endpoint + "?" + param_str(parameters) : endpoint)
       JSON.parse(Net::HTTP.get_response(uri).body, symbolize_names: true)
     rescue
       { error: true }

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -65,8 +65,8 @@ class App < Sinatra::Base
       parameters.map { |key, value| key.to_s + "=" + CGI.escape(value.to_s) }.join("&")
     end
 
-    def http_get(endpoint, parameters)
-      uri = URI.parse(endpoint + "?" + param_str(parameters))
+    def http_get(endpoint, parameters = {})
+      uri = URI.parse(parameters.length > 0 ? endpoint + "?" + param_str(parameters) : endpoint)
       JSON.parse(Net::HTTP.get_response(uri).body, symbolize_names: true)
     rescue
       { error: true }

--- a/spec/lib/msplex/resource/frontend_spec.rb
+++ b/spec/lib/msplex/resource/frontend_spec.rb
@@ -75,8 +75,8 @@ class App < Sinatra::Base
       parameters.map { |key, value| key.to_s + "=" + CGI.escape(value.to_s) }.join("&")
     end
 
-    def http_get(endpoint, parameters)
-      uri = URI.parse(endpoint + "?" + param_str(parameters))
+    def http_get(endpoint, parameters = {})
+      uri = URI.parse(parameters.length > 0 ? endpoint + "?" + param_str(parameters) : endpoint)
       JSON.parse(Net::HTTP.get_response(uri).body, symbolize_names: true)
     rescue
       { error: true }

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -84,8 +84,8 @@ class App < Sinatra::Base
       parameters.map { |key, value| key.to_s + "=" + CGI.escape(value.to_s) }.join("&")
     end
 
-    def http_get(endpoint, parameters)
-      uri = URI.parse(endpoint + "?" + param_str(parameters))
+    def http_get(endpoint, parameters = {})
+      uri = URI.parse(parameters.length > 0 ? endpoint + "?" + param_str(parameters) : endpoint)
       JSON.parse(Net::HTTP.get_response(uri).body, symbolize_names: true)
     rescue
       { error: true }


### PR DESCRIPTION
Currently `#http_get` expects one or more parameters.
