### PR TITLE
Set entrypoint

### DIFF
--- a/lib/msplex/generator.rb
+++ b/lib/msplex/generator.rb
@@ -23,6 +23,7 @@ module Msplex
 
       generate_config_ru(@frontend, frontend_dir)
       generate_dockerfile(@frontend, frontend_dir)
+      generate_entrypoint_sh(@frontend, frontend_dir)
       generate_frontend_app_rb(frontend_dir)
       generate_frontend_gemfile(frontend_dir)
       generate_frontend_gemfile_lock(frontend_dir)
@@ -37,6 +38,7 @@ module Msplex
         generate_config_ru(service, service_dir)
         generate_database_yml(database, service_dir)
         generate_dockerfile(service, service_dir)
+        generate_entrypoint_sh(service, service_dir)
         generate_service_app_rb(service, database, service_dir)
         generate_service_gemfile(service, database, service_dir)
         generate_service_gemfile_lock(service, database, service_dir)
@@ -58,6 +60,11 @@ module Msplex
 
     def generate_dockerfile(resource, base_dir)
       File.open(File.join(base_dir, "Dockerfile"), "w+") { |f| f.puts resource.dockerfile }
+    end
+
+    def generate_entrypoint_sh(resource, base_dir)
+      File.open(File.join(base_dir, "entrypoint.sh"), "w+") { |f| f.puts resource.entrypoint_sh }
+      FileUtils.chmod("a+x", File.join(base_dir, "entrypoint.sh"))
     end
 
     def generate_frontend_app_rb(base_dir)

--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -110,9 +110,6 @@ CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
         <<-ENTRYPOINT
 #!/bin/bash
 
-bundle exec rake db:create
-bundle exec rake db:migrate
-
 exec $@
 ENTRYPOINT
       end

--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -105,6 +105,17 @@ CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
         DOCKERFILE
       end
 
+      def entrypoint_sh
+        <<-ENTRYPOINT
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@
+ENTRYPOINT
+      end
+
       def gemfile
         <<-GEMFILE
 source "https://rubygems.org"

--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -101,6 +101,7 @@ ADD . /usr/src/app
 
 EXPOSE 9292
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
         DOCKERFILE
       end

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -119,6 +119,8 @@ RUN bundle install --without test development --system
 ADD . /usr/src/app
 
 EXPOSE 80
+
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "80", "-E", "production"]
 DOCKERFILE
       end

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -123,6 +123,17 @@ CMD ["bundle", "exec", "rackup", "-p", "80", "-E", "production"]
 DOCKERFILE
       end
 
+      def entrypoint_sh
+        <<-ENTRYPOINT
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@
+ENTRYPOINT
+      end
+
       def gemfile(database)
         <<-GEMFILE.gsub(/^$/, "")
 source "https://rubygems.org"

--- a/spec/fixtures/frontend/Dockerfile
+++ b/spec/fixtures/frontend/Dockerfile
@@ -18,4 +18,5 @@ ADD . /usr/src/app
 
 EXPOSE 9292
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]

--- a/spec/fixtures/frontend/entrypoint.sh
+++ b/spec/fixtures/frontend/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@

--- a/spec/fixtures/frontend/entrypoint.sh
+++ b/spec/fixtures/frontend/entrypoint.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-bundle exec rake db:create
-bundle exec rake db:migrate
-
 exec $@

--- a/spec/fixtures/service/Dockerfile
+++ b/spec/fixtures/service/Dockerfile
@@ -15,4 +15,6 @@ RUN bundle install --without test development --system
 ADD . /usr/src/app
 
 EXPOSE 80
+
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "80", "-E", "production"]

--- a/spec/fixtures/service/entrypoint.sh
+++ b/spec/fixtures/service/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@

--- a/spec/lib/msplex/generator_spec.rb
+++ b/spec/lib/msplex/generator_spec.rb
@@ -212,8 +212,18 @@ ADD . /usr/src/app
 RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 9292
+
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
 DOCKERFILE
+          entrypoint_sh: <<-ENTRYPOINT,
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@
+ENTRYPOINT
           gemfile: <<-GEMFILE,
 source "https://rubygems.org"
 
@@ -318,6 +328,12 @@ HTML
         expect(open(File.join(out_dir, "frontend", "Dockerfile")).read).to match(/FROM ruby:2.3.0/)
       end
 
+      it "should generate entrypoint.sh" do
+        subject
+        expect(open(File.join(out_dir, "frontend", "entrypoint.sh")).read).to match(/#!\/bin\/bash/)
+        expect(File.executable?(File.join(out_dir, "frontend", "entrypoint.sh"))).to eq true
+      end
+
       it "should generate Gemfile" do
         subject
         expect(open(File.join(out_dir, "frontend", "Gemfile")).read).to match(/gem "sinatra"/)
@@ -419,8 +435,18 @@ ADD . /usr/src/app
 RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 9292
+
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["bundle", "exec", "rackup", "-p", "9292", "-E", "production"]
 DOCKERFILE
+          entrypoint_sh: <<-ENTRYPOINT,
+#!/bin/bash
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+exec $@
+ENTRYPOINT
             gemfile: <<-GEMFILE,
 source "https://rubygems.org"
 
@@ -569,6 +595,12 @@ MIGRATION
       it "should generate Dockerfile" do
         subject
         expect(open(File.join(out_dir, "services", "hoge", "Dockerfile")).read).to match(/FROM ruby:2.3.0/)
+      end
+
+      it "should generate entrypoint.sh" do
+        subject
+        expect(open(File.join(out_dir, "services", "hoge", "entrypoint.sh")).read).to match(/#!\/bin\/bash/)
+        expect(File.executable?(File.join(out_dir, "services", "hoge", "entrypoint.sh"))).to eq true
       end
 
       it "should generate Gemfile" do

--- a/spec/lib/msplex/resource/frontend_spec.rb
+++ b/spec/lib/msplex/resource/frontend_spec.rb
@@ -116,6 +116,14 @@ ELEMENTS
         end
       end
 
+      describe "#entrypoint_sh" do
+        subject { frontend.entrypoint_sh }
+
+        it "should generate entrypoint.sh" do
+          expect(subject).to eq fixture_of("frontend", "entrypoint.sh")
+        end
+      end
+
       describe "#gemfile" do
         subject { frontend.gemfile }
 

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -123,6 +123,14 @@ CREATE
         end
       end
 
+      describe "#entrypoint_sh" do
+        subject { service.entrypoint_sh }
+
+        it "should generate enrtypoint.sh" do
+          expect(subject).to eq fixture_of("service", "entrypoint.sh")
+        end
+      end
+
       describe "#gemfile" do
         subject { service.gemfile(database) }
 


### PR DESCRIPTION
## WHY

To execute `db:create` and `db:migrate` automatically at the launch time.
## WHAT

Set `entrypoint.sh` to do them before launch web server.
