### PR TITLE
Put nginx-proxy container at the front of microservices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.7
-  - 2.0
 before_install: gem install bundler -v 1.10.6
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Microservice-based Web Application Generator
 
+## Supported version
+
+Ruby 2.1 or above
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/msplex/generator.rb
+++ b/lib/msplex/generator.rb
@@ -11,7 +11,10 @@ module Msplex
     end
 
     def generate_compose
-      compose_yml = { frontend: @frontend.compose(@services) }
+      compose_yml = {
+        frontend: @frontend.compose(@services),
+        nginx: nginx_compose,
+      }
       service_database_pairs.each { |service, database| compose_yml[service.compose_service_name] = service.compose(database) }
       @databases.each { |database| compose_yml[database.compose_service_name] = database.compose }
       write_compose(compose_yml)
@@ -117,6 +120,15 @@ module Msplex
 
     def generate_rakefile(resource, base_dir)
       File.open(File.join(base_dir, "Rakefile"), "w+") { |f| f.puts resource.rakefile }
+    end
+
+    def nginx_compose
+      {
+        image: "jwilder/nginx-proxy:latest",
+        volumes: [
+          "/var/run/docker.sock:/tmp/docker.sock:ro",
+        ],
+      }
     end
 
     def service_database_pairs

--- a/lib/msplex/resource/frontend.rb
+++ b/lib/msplex/resource/frontend.rb
@@ -257,7 +257,7 @@ ENDPOINT
       end
 
       def links(services)
-        services.map { |service| "#{service.compose_service_name}:#{service.name}" }
+        services.map { |service| "nginx:#{service.name}" }
       end
 
       def navbar_items

--- a/lib/msplex/resource/service.rb
+++ b/lib/msplex/resource/service.rb
@@ -39,6 +39,9 @@ module Msplex
       def compose(database)
         {
           build: "services/#{@name}",
+          environment: [
+            "VIRTUAL_HOST=#{@name}"
+          ],
           links: links(database),
         }
       end

--- a/spec/lib/msplex/generator_spec.rb
+++ b/spec/lib/msplex/generator_spec.rb
@@ -52,8 +52,8 @@ module Msplex
           compose: {
             image: "ruby:2.3.0",
             links: [
-              "hoge_service:hoge",
-              "fuga_service:fuga",
+              "nginx:hoge",
+              "nginx:fuga",
             ]
           }
         )
@@ -64,26 +64,26 @@ module Msplex
           double(:service,
             name: "hoge",
             compose: {
-              image: "ruby:2.3.0",
+              build: "services/hoge",
+              environment: [
+                "VIRTUAL_HOST=hoge",
+              ],
               links: [
                 "hoge_db:db",
               ],
-              environment: [
-                "RACK_ENV=production",
-              ]
             },
             compose_service_name: "hoge_service",
           ),
           double(:service,
             name: "fuga",
             compose: {
-              image: "ruby:2.3.0",
+              build: "services/fuga",
+              environment: [
+                "VIRTUAL_HOST=fuga",
+              ],
               links: [
                 "fuga_db:db",
               ],
-              environment: [
-                "RACK_ENV=production",
-              ]
             },
             compose_service_name: "fuga_service",
           )
@@ -122,20 +122,20 @@ module Msplex
 frontend:
   image: ruby:2.3.0
   links:
-  - hoge_service:hoge
-  - fuga_service:fuga
+  - nginx:hoge
+  - nginx:fuga
 hoge_service:
-  image: ruby:2.3.0
+  build: services/hoge
+  environment:
+  - VIRTUAL_HOST=hoge
   links:
   - hoge_db:db
-  environment:
-  - RACK_ENV=production
 fuga_service:
-  image: ruby:2.3.0
+  build: services/fuga
+  environment:
+  - VIRTUAL_HOST=fuga
   links:
   - fuga_db:db
-  environment:
-  - RACK_ENV=production
 hoge_db:
   image: postgres:9.4
 fuga_db:

--- a/spec/lib/msplex/generator_spec.rb
+++ b/spec/lib/msplex/generator_spec.rb
@@ -124,6 +124,10 @@ frontend:
   links:
   - nginx:hoge
   - nginx:fuga
+nginx:
+  image: jwilder/nginx-proxy:latest
+  volumes:
+  - "/var/run/docker.sock:/tmp/docker.sock:ro"
 hoge_service:
   build: services/hoge
   environment:

--- a/spec/lib/msplex/resource/frontend_spec.rb
+++ b/spec/lib/msplex/resource/frontend_spec.rb
@@ -73,8 +73,8 @@ ELEMENTS
             expect(subject).to eql({
               build: "frontend",
               links: [
-                "hoge_service:hoge",
-                "fuga_service:fuga",
+                "nginx:hoge",
+                "nginx:fuga",
               ],
               ports: [
                 "80:9292"

--- a/spec/lib/msplex/resource/service_spec.rb
+++ b/spec/lib/msplex/resource/service_spec.rb
@@ -86,6 +86,9 @@ DELETE
           it "should generate docker-compose.yml linked with database" do
             expect(subject).to eql({
               build: "services/sample",
+              environment: [
+                "VIRTUAL_HOST=sample",
+              ],
               links: [
                 "sample_db:db",
               ],
@@ -101,6 +104,9 @@ DELETE
           it "should generate docker-compose.yml" do
             expect(subject).to eql({
               build: "services/sample",
+              environment: [
+                "VIRTUAL_HOST=sample",
+              ],
               links: [],
             })
           end


### PR DESCRIPTION
## WHY

Docker Compose enables us to scale up/down microservice containers. However, there is no way to distribute requests to multiple microservice containers.
## WHAT

jwilder/nginx-proxy enables us to do load balancing dynamically.

```
                              +--> service_01              
--> frontend --> nginx-proxy -+--> service_02
                              +--> service_03
```
